### PR TITLE
wrap callbacks in useCallback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import Web3Modal, { ICoreOptions } from 'web3modal';
 import { Network, Web3Provider } from '@ethersproject/providers';
 import create from 'zustand';
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 
 type State = {
   provider?: Web3Provider;
@@ -31,7 +31,7 @@ export const useWallet: UseWallet = () => {
     useStore.setState({ web3Modal: new Web3Modal() });
   }, []);
 
-  const connect: ConnectWallet = async opts => {
+  const connect: ConnectWallet = useCallback(async opts => {
     // Launch modal with the given options
     const web3Modal = new Web3Modal(opts);
     useStore.setState({ web3Modal });
@@ -61,16 +61,16 @@ export const useWallet: UseWallet = () => {
     web3ModalProvider.on('disconnect', () => {
       web3Modal.clearCachedProvider();
     });
-  };
+  }, []);
 
-  const disconnect: DisconnectWallet = async () => {
+  const disconnect: DisconnectWallet = useCallback(async () => {
     web3Modal?.clearCachedProvider();
     useStore.setState({
       provider: undefined,
       network: undefined,
       account: undefined,
     });
-  };
+  }, [web3Modal?.clearCachedProvider]);
 
   return {
     connect,


### PR DESCRIPTION
to allow for better dep management downstream

otherwise I get
![image](https://user-images.githubusercontent.com/508855/146315377-bc1efbdf-97a5-47a7-ae47-154240dbe9cc.png)

here's my use case:
https://github.com/holic/tweets-on-chain/blob/d7debe9b701b74b9026f5f37daeeeb4ea09c7deb/packages/app/src/useWallet.ts#L6-L7
(had to temporarily wrap in my own `useCallback` without deps and disable the eslint warning about missing deps)

I did not test this!